### PR TITLE
Enable pipeline for pull requests

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,6 +6,7 @@ on:
       - 'main'
     tags:
       - 'v[0-9]+.[0-9]+.[0-9]+'
+    pull_request:
 
 env:
   IMAGE_NAME: endresshauser/zephyr-box
@@ -39,6 +40,7 @@ jobs:
             # set latest tag for main branch
             type=raw,value=latest,enable=${{ github.ref == format('refs/heads/{0}', 'main') }}
             type=semver,pattern={{major}}.{{minor}},enable=${{ startsWith(github.ref, 'refs/tags/v') }}
+            type=ref,event=pr,enable=${{ !!github.event.pull_request }}
 
       - name: Build and push Docker image
         uses: docker/build-push-action@v6


### PR DESCRIPTION
Enable pipeline for pull requests. Containers from pull requests will be tagged using the pull request number e.g. `zephyr-box:pr-123`. This allows for easier testing of PRs.