### PR TITLE
Improvements for run_in_docker script

### DIFF
--- a/run_in_docker.sh
+++ b/run_in_docker.sh
@@ -6,7 +6,7 @@ SSH_DIR=${SSH_DIR:-"${HOME}/.ssh"}
 RUN_LOCALLY=${RUN_LOCALLY:-"true"}
 RUN_WITH_TTY=${RUN_WITH_TTY:-"true"}
 
-DOCKER_REGISTRY=${DOCKER_REGISTRY:-"docker.io/endresshauser"}
+DOCKER_REGISTRY=${DOCKER_REGISTRY:-"ghcr.io/endresshauser-lp"}
 IMAGE_NAME="zephyr-box"
 
 USER_UID=$(id -u "$(whoami)")


### PR DESCRIPTION
- Update default registry to ghcr.io/endresshauser-lp
- We already build container images for pull request, but we stilled missed support to use these together with `run_in_docker.sh`
- Allow to use other container runtimes like podman