### PR TITLE
Make Zephyr pickup ccache before 4.12 and add basic config

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -143,6 +143,12 @@ RUN dpkg --add-architecture i386 \
     && update-alternatives --install /usr/bin/cc cc /usr/bin/gcc-14 50 \
     && ln -s x86_64-linux-gnu/asm /usr/include/asm
 
+
+# --- ccache: allow the Ubuntu 24.04 ccache (4.9.1) to be used by Zephyr ---
+ENV CCACHE_IGNOREOPTIONS='-specs=* --specs=*'
+ENV CCACHE_CONFIGPATH=/etc/ccache.conf
+COPY ./ccache.conf /etc/ccache.conf
+
 #
 # --- Zephyr SDK toolchain ---
 #

--- a/ccache.conf
+++ b/ccache.conf
@@ -1,0 +1,3 @@
+depend_mode = false
+sloppiness = include_file_mtime,include_file_ctime,system_headers,file_macro
+compiler_check = content


### PR DESCRIPTION
This PR adds  `ENV CCACHE_IGNOREOPTIONS='-specs=* --specs=*'` to Dockerfile, making our 4.9 ccache work (it stopped working at all because of https://github.com/zephyrproject-rtos/zephyr/pull/109421)

Also adds basic ccache config file.